### PR TITLE
Flip board orientation for gote players

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -264,6 +264,9 @@ function renderStatus() {
 }
 
 function renderBoard() {
+  const isFlipped = myColor === COLORS.GOTE;
+  boardEl.classList.toggle('flipped', isFlipped);
+
   const cells = boardEl.children;
   const highlightMap = new Map();
   const dropMap = new Map();

--- a/public/styles.css
+++ b/public/styles.css
@@ -165,6 +165,10 @@ main {
   background: var(--board-dark);
 }
 
+.board.flipped {
+  transform: rotate(180deg);
+}
+
 .cell {
   position: relative;
   display: flex;


### PR DESCRIPTION
## Summary
- flip the client board when the viewer is assigned gote so their home rank sits at the bottom
- add styling to rotate the board when flipped while keeping existing highlights intact

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dc15fc26108329866e6f1b502ed598